### PR TITLE
Fix message posting error in chat rooms

### DIFF
--- a/js/jquery.chat.js
+++ b/js/jquery.chat.js
@@ -426,7 +426,7 @@ jQuery(function($)
 
 	var updateProccess = function(data)
 	{
-		if ( Object.keys(data).length == 0 )
+		if ( !data || Object.keys(data).length == 0 )
 		{
 			return;
 		}


### PR DESCRIPTION
Fixed "Cannot convert undefined or null to object" error that occurred when posting messages in chat rooms. The issue was in updateProccess() at line 429 where Object.keys() was called on potentially null/undefined data returned from AJAX calls. Added null check before Object.keys().